### PR TITLE
Group service

### DIFF
--- a/docker-compose/data/groups/groups.sql
+++ b/docker-compose/data/groups/groups.sql
@@ -27,8 +27,8 @@ INSERT INTO T_users (user_id) VALUES (4);
 
 DROP TABLE if exists T_groups_users CASCADE;
 CREATE TABLE T_groups_users (
-    group_id int NOT NULL REFERENCES T_users(user_id),
-    user_id int NOT NULL REFERENCES T_groups(group_id)
+    group_id int REFERENCES T_groups(group_id),
+    user_id int REFERENCES T_users(user_id)
 );
 TRUNCATE TABLE T_groups_users;
 INSERT INTO T_groups_users (group_id, user_id) VALUES (1, 1);

--- a/group-service/src/main/java/api/GroupRestService.java
+++ b/group-service/src/main/java/api/GroupRestService.java
@@ -104,20 +104,24 @@ public class GroupRestService {
         }
 
         Group returnedGroup=groupService.createGroup(group); // can never have conflict if id are auto-incremented.
+        if (returnedGroup == null){
+            log.severe("Tried to create Group: id=" + group.getId() + " name=" +group.getId()+ " admin_id="+group.getAdmin_id() + " with some users but either id was non zero or group had null name or some of the users had user id was 1");
+            return Response.status(Response.Status.BAD_REQUEST).entity("BAD_REQUEST : Tried to create Group: id=" + group.getId() + " name=" +group.getId()+ " admin_id="+group.getAdmin_id() + " with some users but either id was non zero or group had null name or some of the users had user id was 1").build();
+        }
         // returnedGroup can be null in general but we tested the input before so it's not null.. otherwise bad request..
         UriBuilder uriBuilder = uriInfo.getAbsolutePathBuilder(); // https://www.logicbig.com/tutorials/java-ee-tutorial/jax-rs/uri-info.html
         uriBuilder.path(Integer.toString(returnedGroup.getId()));
         return Response.created(uriBuilder.build()).entity(returnedGroup).build(); // 201
     }
 
-    @PUT
+    @POST
     @Path("/{group_id}/users/")  // TODO: maybe add another HTTP method for get {group_id}/users/{user_id}
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Adding a new user to an existing group")
     public Response addUserToGroup(@PathParam("group_id") String str_id, User user){ // TODO: check if user already in group
         /*
-        Add a new user to an existing group. Need to know the id of the group to update. Return modified object.
+        Add an user to an existing group. Need to know the id of the group to update. Return modified object.
          */
 
         try {
@@ -130,7 +134,7 @@ public class GroupRestService {
             }
 
             if (user.getGroups() == null){
-                user.setGroups(new HashSet<Group>()); // empty set
+                user.setGroups(new HashSet<>()); // empty set
             }
 
             Group returnedGroup=groupService.addUserToGroup(id, user);

--- a/group-service/src/main/java/domain/model/Group.java
+++ b/group-service/src/main/java/domain/model/Group.java
@@ -24,14 +24,7 @@ import javax.persistence.ManyToMany;
 import javax.persistence.CascadeType;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
-import javax.persistence.FetchType;
 // https://youtu.be/FeZ5BC0PirQ
-
-import domain.model.User;
-
-import com.fasterxml.jackson.annotation.JsonBackReference;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
-
 
 @ToString
 @Getter
@@ -52,7 +45,7 @@ public class Group {
             joinColumns={@JoinColumn(name="group_id", referencedColumnName="group_id")},
             inverseJoinColumns={@JoinColumn(name="user_id", referencedColumnName="user_id")})
     @Setter
-    private Set<User> users = new HashSet<User>();  // https://www.appsdeveloperblog.com/infinite-recursion-in-objects-with-bidirectional-relationships/
+    private Set<User> users = new HashSet<>();  // https://www.appsdeveloperblog.com/infinite-recursion-in-objects-with-bidirectional-relationships/
     // https://thorben-janssen.com/6-hibernate-mappings-you-should-avoid-for-high-performance-applications/
     public Group(String name){
         this.name = name;

--- a/group-service/src/main/java/domain/model/User.java
+++ b/group-service/src/main/java/domain/model/User.java
@@ -22,18 +22,7 @@ import javax.persistence.Table;
 import javax.persistence.Column;
 
 import javax.persistence.ManyToMany;
-import javax.persistence.CascadeType;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.FetchType;
 // https://youtu.be/FeZ5BC0PirQ
-
-import domain.model.Group;
-
-
-import com.fasterxml.jackson.annotation.JsonBackReference;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
-
 
 @ToString
 @Getter
@@ -46,7 +35,7 @@ public class User {
 
     @ManyToMany(mappedBy = "users")
     @Setter @JsonIgnore
-    private Set<Group> groups = new HashSet<Group>();  // https://www.appsdeveloperblog.com/infinite-recursion-in-objects-with-bidirectional-relationships/
+    private Set<Group> groups = new HashSet();  // https://www.appsdeveloperblog.com/infinite-recursion-in-objects-with-bidirectional-relationships/
     // https://thorben-janssen.com/6-hibernate-mappings-you-should-avoid-for-high-performance-applications/
     public User(int id){
         this.id=id;

--- a/group-service/src/main/java/domain/model/User.java
+++ b/group-service/src/main/java/domain/model/User.java
@@ -15,8 +15,6 @@ import javax.validation.constraints.NotNull;
 // https://projectlombok.org/features/all
 
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.persistence.Column;

--- a/group-service/src/main/resources/META-INF/groups_test.sql
+++ b/group-service/src/main/resources/META-INF/groups_test.sql
@@ -20,7 +20,7 @@ INSERT INTO T_users (user_id) VALUES (3);
 INSERT INTO T_users (user_id) VALUES (4);
 
 DROP TABLE if exists T_groups_users CASCADE;
-CREATE TABLE T_groups_users (group_id int NOT NULL REFERENCES T_users(user_id), user_id int NOT NULL REFERENCES T_groups(group_id));
+CREATE TABLE T_groups_users (group_id int REFERENCES T_groups(group_id), user_id int REFERENCES T_users(user_id));
 TRUNCATE TABLE T_groups_users;
 INSERT INTO T_groups_users (group_id, user_id) VALUES (1, 1);
 INSERT INTO T_groups_users (group_id, user_id) VALUES (1, 2);

--- a/group-service/src/main/resources/META-INF/persistence.xml
+++ b/group-service/src/main/resources/META-INF/persistence.xml
@@ -10,6 +10,7 @@
         <!-- This is done like this because we run the .war using thorntail-maven-plugin before the IT-->
         <jta-data-source>java:jboss/datasources/groupds</jta-data-source>
         <class>domain.model.Group</class> <!-- we need this otherwise, it thinks group is not an entity -->
+        <class>domain.model.User</class>
         <!-- https://youtu.be/FeZ5BC0PirQ, https://gist.github.com/SergioDiniz/886723272d9fd95dd17ecb79b35b66e1 -->
         <properties>
             <!--property name="hibernate.hbm2ddl.auto" value="update" /--> <!-- used to create automatically new db etc. not used in prod-->

--- a/group-service/src/test/java/domain/model/GroupTest.java
+++ b/group-service/src/test/java/domain/model/GroupTest.java
@@ -3,7 +3,13 @@ package domain.model;
 // Unit/Component testing using JUnit 5
 // https://junit.org/junit5/docs/current/user-guide/#writing-tests
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.infinispan.commons.hash.Hash;
 import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.HashSet;
 
 // just a test for unit testing
 class GroupTest {
@@ -20,10 +26,76 @@ class GroupTest {
     }
 
     @Test
+    void testGetAdmin_id(){
+        assertEquals(0, group.getAdmin_id() );
+    }
+
+    @Test
+    void testGetUsers(){
+        assertEquals(0, new Group().getUsers().size() );
+    }
+
+    @Test
     void testSetName(){
         Group tmpgroup = new Group("hello world");
         tmpgroup.setName("hello universe");
         assertEquals("hello universe", tmpgroup.getName() );
+    }
+
+    @Test
+    void testSetAdmin_id(){
+        Group tmpgroup = new Group("hello world");
+        tmpgroup.setAdmin_id(10);
+        assertEquals(10, tmpgroup.getAdmin_id() );
+    }
+
+    @Test
+    void testSetUsers(){
+        Group tmpgroup = new Group("hello world");
+        User usr1 = new User(1);
+        User usr2 = new User(2);
+        Set<User> users = new HashSet<>();
+        users.add(usr1);
+        users.add(usr2);
+
+        tmpgroup.setUsers(users);
+
+        assertEquals(users, tmpgroup.getUsers() );
+    }
+
+    @Test
+    void testAddUsers(){
+        Group tmpgroup = new Group("hello world");
+        User usr1 = new User(1);
+        User usr2 = new User(2);
+        Set<User> users = new HashSet<>();
+        users.add(usr1);
+        users.add(usr2);
+
+        tmpgroup.addUser(usr1);
+        tmpgroup.addUser(usr2);
+
+        assertEquals(users, tmpgroup.getUsers() );
+    }
+
+    @Test
+    void testRemoveUsers(){
+        Group tmpgroup = new Group("hello world");
+        User usr1 = new User(1);
+        User usr2 = new User(2);
+        Set<User> users = new HashSet<>();
+        users.add(usr1);
+        users.add(usr2);
+
+        tmpgroup.addUser(usr1);
+        tmpgroup.addUser(usr2);
+
+        assertEquals(users, tmpgroup.getUsers() );
+
+        tmpgroup.removeUser(usr1);
+        tmpgroup.removeUser(usr2);
+
+        assertEquals(0, tmpgroup.getUsers().size() );
     }
 
     @Test
@@ -33,12 +105,21 @@ class GroupTest {
 
     @Test
     void testGetNameNoArgsConstructor(){
-        assertEquals(null, new Group().getName() );
+        assertNull(new Group().getName() );
+    }
+
+    @Test
+    void testGetAdmin_idNoArgsConstructor(){
+        assertEquals(0, new Group().getAdmin_id() );
+    }
+
+    @Test
+    void testGetUsersNoArgsConstructor(){
+        assertEquals(0, new Group().getUsers().size() );
     }
 
     @Test
     void testToString(){
         assertEquals("Group(id=0, name=hello world, admin_id=0, users=[])", group.toString() );
     }
-    // fail a test -> Build failure
 }

--- a/group-service/src/test/java/domain/model/UserTest.java
+++ b/group-service/src/test/java/domain/model/UserTest.java
@@ -1,0 +1,90 @@
+package domain.model;
+
+// Unit/Component testing using JUnit 5
+// https://junit.org/junit5/docs/current/user-guide/#writing-tests
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+// just a test for unit testing
+class UserTest {
+    private final User user = new User(1);
+
+    @Test
+    void testGetId(){
+        assertEquals(1, user.getId() );
+    }
+
+    @Test
+    void testGetGroups(){
+        assertEquals(0, new User().getGroups().size() );
+    }
+
+    @Test
+    void testSetGroups(){
+        User tmpuser = new User(1);
+        Group grp1 = new Group("hello");
+        Group grp2 = new Group("world");
+        Set<Group> groups = new HashSet<>();
+        groups.add(grp1);
+        groups.add(grp2);
+
+        tmpuser.setGroups(groups);
+
+        assertEquals(groups, tmpuser.getGroups() );
+    }
+
+    @Test
+    void testAddGroups(){
+        User tmpuser = new User(1);
+        Group grp1 = new Group("hello");
+        Group grp2 = new Group("world");
+        Set<Group> groups = new HashSet<>();
+        groups.add(grp1);
+        groups.add(grp2);
+
+        tmpuser.addGroup(grp1);
+        tmpuser.addGroup(grp2);
+
+        assertEquals(groups, tmpuser.getGroups() );
+    }
+
+    @Test
+    void testRemoveGroups(){
+        User tmpuser = new User(1);
+        Group grp1 = new Group("hello");
+        Group grp2 = new Group("world");
+        Set<Group> groups = new HashSet<>();
+        groups.add(grp1);
+        groups.add(grp2);
+
+        tmpuser.addGroup(grp1);
+        tmpuser.addGroup(grp2);
+
+        assertEquals(groups, tmpuser.getGroups() );
+
+        tmpuser.removeGroup(grp1);
+        tmpuser.removeGroup(grp2);
+
+        assertEquals(0, tmpuser.getGroups().size() );
+    }
+
+    @Test
+    void testGetIdNoArgsConstructor(){
+        assertEquals(0, new User().getId() );
+    }
+
+    @Test
+    void testGetUsersNoArgsConstructor(){
+        assertEquals(0, new User().getGroups().size() );
+    }
+
+    @Test
+    void testToString(){
+        assertEquals("User(id=1, groups=[])", user.toString() );
+    }
+}

--- a/group-service/src/test/resources/META-INF/groups_test.sql
+++ b/group-service/src/test/resources/META-INF/groups_test.sql
@@ -20,7 +20,7 @@ INSERT INTO T_users (user_id) VALUES (3);
 INSERT INTO T_users (user_id) VALUES (4);
 
 DROP TABLE if exists T_groups_users CASCADE;
-CREATE TABLE T_groups_users (group_id int NOT NULL REFERENCES T_users(user_id), user_id int NOT NULL REFERENCES T_groups(group_id));
+CREATE TABLE T_groups_users (group_id int REFERENCES T_groups(group_id), user_id int REFERENCES T_users(user_id));
 TRUNCATE TABLE T_groups_users;
 INSERT INTO T_groups_users (group_id, user_id) VALUES (1, 1);
 INSERT INTO T_groups_users (group_id, user_id) VALUES (1, 2);


### PR DESCRIPTION
# Major features that seems to work but NOT tested:
- GET set of groups
- GET a particular group
(including admin_id for a `user`, by default 0, `name` of group, set of Users)
- DELETE entirely a group in one request
- (PUT) modify  entire group in one request (it can erase attributes ! or override, for instance lose all the members !!!)
- (POST) add user one by one in a group (at `/groups/{group_id}/users`).
- (POST) create a new group **but only** with a `name` and `admin_id`

The last two works even if the user wasn't in the user table in the db before (creates new user before creating group).
Also seems (not tested) to work even if add user that existed in the group.

`admin_id` can **only** be modified by updating the entire group through the POST method or at the creation of the group.

# TODO:
- Maybe rename users to **members**
- Delete only one user one by one from a group (add a new request DELETE at `/groups/{group_id}/users`).
- Create a group direclty with one or more users !
- Link with future authentication to assign the admin_id to the user that created the group

`admin_id` can **only** be modified by updating the entire group through the PUT method or at the creation of the group. 
- Add new method to modify the `admin_id` only
- Add new method to modify the `name` of the group only
- Add new method to get only a list of user ids.
- Add (short-term) preferences
- Add booleans for front-end and poll-service to use to switch windows when votes are done etc.
- Also update comments