### PR TITLE
Group service

### DIFF
--- a/group-service/src/main/java/api/GroupRestService.java
+++ b/group-service/src/main/java/api/GroupRestService.java
@@ -16,7 +16,6 @@ import domain.model.User;
 // service
 import domain.service.GroupService;
 
-import java.util.Set;
 import java.util.HashSet;
 
 /*
@@ -88,8 +87,10 @@ public class GroupRestService {
         Create a group and returns HTTP status code and the location of the newly created object. It's possible to create multiple
         groups with same name. The unique identifier is its id that auto increments. We cannot input a group having an id !!
 
-        Example with curl:
+        Examples with curl:
         - curl --verbose -H "Content-Type: application/json" -X POST http://localhost:10080/groups -d '{"name":"test"}'
+        - curl --verbose -H "Content-Type: application/json" -X POST http://localhost:10080/groups -d '{"name":"test", "admin_id": 1000}'
+        - curl --verbose -H "Content-Type: application/json" -X POST http://localhost:10080/groups -d '{"name":"test", "admin_id": 1000, "users": [{"id": 10}, {"id": 42}, {"id":3}, {"id":6}]}'
 
          Then you use GET to see the created object
         */

--- a/group-service/src/main/java/api/GroupRestService.java
+++ b/group-service/src/main/java/api/GroupRestService.java
@@ -100,7 +100,7 @@ public class GroupRestService {
         }
 
         if (group.getUsers() == null){
-            group.setUsers(new HashSet<User>()); // empty set
+            group.setUsers(new HashSet<>()); // empty set
         }
 
         Group returnedGroup=groupService.createGroup(group); // can never have conflict if id are auto-incremented.
@@ -196,7 +196,7 @@ public class GroupRestService {
         }
 
         if (group.getUsers() == null){
-            group.setUsers(new HashSet<User>()); // empty set
+            group.setUsers(new HashSet<>()); // empty set
         }
 
         Group returnedGroup=groupService.updateGroup(group); // get all groups and check if group inside list of groups

--- a/group-service/src/main/java/api/GroupRestService.java
+++ b/group-service/src/main/java/api/GroupRestService.java
@@ -126,7 +126,7 @@ public class GroupRestService {
          */
 
         try {
-            log.info("Trying to add user " + user + "in a Group having id=" + str_id);
+            log.info("Trying to add user with user_id=" + user.getId() + "in a Group having id=" + str_id);
             int id = Integer.parseInt(str_id);
 
             // user id can be 0..
@@ -159,7 +159,7 @@ public class GroupRestService {
         Remove an user from an existing group. Need to know the id of the group and the id of the user to remove. Return modified object.
          */
         try {
-            log.info("Trying to remove user with id=" + str_user_id + "from a Group having id=" + str_group_id);
+            log.info("Trying to remove user with user_id=" + str_user_id + "from a Group having group_id=" + str_group_id);
             int group_id = Integer.parseInt(str_group_id);
             int user_id = Integer.parseInt(str_user_id);
 

--- a/group-service/src/main/java/domain/service/GroupService.java
+++ b/group-service/src/main/java/domain/service/GroupService.java
@@ -5,10 +5,11 @@ import domain.model.Group;
 import domain.model.User;
 
 public interface GroupService{
-    public Set<Group> getAllGroups(); // called by GET request
-    public Group getGroup(int id); // called by GET request
-    public Group createGroup(Group group); // called by POST request
-    public Group addUserToGroup(int id, User user); // called by PUT request
-    public Group updateGroup(Group group); // called by PUT request
-    public Group deleteGroup(int id); // called by DELETE request
+    Set<Group> getAllGroups(); // called by GET request
+    Group getGroup(int id); // called by GET request
+    Group createGroup(Group group); // called by POST request
+    Group addUserToGroup(int id, User user); // called by PUT request
+    Group removeUserFromGroup(int group_id, int user_id); // called by DELETE request
+    Group updateGroup(Group group); // called by PUT request
+    Group deleteGroup(int id); // called by DELETE request
 }

--- a/group-service/src/main/java/domain/service/GroupServiceImpl.java
+++ b/group-service/src/main/java/domain/service/GroupServiceImpl.java
@@ -123,6 +123,7 @@ public class GroupServiceImpl implements GroupService{
             else{ // user already exists, merge user
                 em.merge(user);
             }
+            user.addGroup(group);
         }
         em.persist(group);
         return group;
@@ -143,6 +144,7 @@ public class GroupServiceImpl implements GroupService{
             if (usr.getId() == user.getId()){
                 // user id already in group
                 user_already_in_group= true;
+                break;
             }
         }
         if (!user_already_in_group){
@@ -192,11 +194,12 @@ public class GroupServiceImpl implements GroupService{
             if (usr.getId() == user.getId()){
                 // user id in the group ! so we can remove later
                 user_in_group= true;
+                break;
             }
         }
         if (user_in_group){
-            group.removeUser(user);
-            em.remove(user);
+            group.removeUser(user);  // user can still exist, just removed from the group
+            em.merge(group);
         }
         else{
             return null; // user not in group
@@ -226,6 +229,7 @@ public class GroupServiceImpl implements GroupService{
             else{ // user already exists, merge user
                 em.merge(user);
             }
+            user.addGroup(group);
         }
         // Group need to exist.
         em.merge(group);

--- a/group-service/src/main/java/domain/service/GroupServiceImpl.java
+++ b/group-service/src/main/java/domain/service/GroupServiceImpl.java
@@ -125,7 +125,7 @@ public class GroupServiceImpl implements GroupService{
         em.persist(tmpgroup);  // tmpgroup becomes managed
 
         for (User user: group.getUsers()){
-            // flushes implicitely each time, not really good in performance because doing tons of requests
+            // flushes implicitely each time, not really good in performance because doing tons of SQL queries
             addUserToGroup(tmpgroup.getId(), user);
         }
         em.merge(tmpgroup);
@@ -208,16 +208,10 @@ public class GroupServiceImpl implements GroupService{
         if (group.getUsers() == null){
             group.setUsers(new HashSet<>()); // empty set
         }
-
+        g.setUsers(new HashSet<>()); // remove all users !!!
         for (User user: group.getUsers()){
-            if (getUser(user.getId()) == null){
-                // user did not exist, create user first
-                em.persist(user); // user was not managed, it becomes managed
-            }
-            else{ // user already exists, merge user
-                em.merge(user);
-            }
-            user.addGroup(group);
+            // flushes implicitely each time, not really good in performance because doing tons of SQL queries
+            addUserToGroup(g.getId(), user);
         }
         // Group need to exist.
         em.merge(group);

--- a/group-service/src/test/java/domain/model/GroupTest.java
+++ b/group-service/src/test/java/domain/model/GroupTest.java
@@ -5,7 +5,6 @@ package domain.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.infinispan.commons.hash.Hash;
 import org.junit.jupiter.api.Test;
 
 import java.util.Set;

--- a/group-service/src/test/java/domain/service/GroupServiceImplTest.java
+++ b/group-service/src/test/java/domain/service/GroupServiceImplTest.java
@@ -59,13 +59,13 @@ class GroupServiceImplTest {
         initDataStore();  // create new groups
         // order not preserved
         Set<Group> groups = groupServiceImpl.getAllGroups(); // get set of groups through the business service
-        List<Group> list_groups = new ArrayList<>(groups);
+        List<Group> list_groups = new ArrayList<>(groups); // shallow copy
 
         int id = list_groups.get(0).getId(); // get the id through Java object ! (set of groups)
 
         Group grp = groupServiceImpl.getGroup(id); // get the specific group through the business service
 
-        assertEquals(list_groups.get(0), grp.getId()); // check the ids
+        assertEquals(list_groups.get(0).getId(), grp.getId()); // check the ids
         assertEquals(list_groups.get(0).getName(), grp.getName());
     }
 
@@ -99,7 +99,7 @@ class GroupServiceImplTest {
     void testCreateWithIdGroup() {
         initDataStore();  // create new groups
         Set<Group> groups = groupServiceImpl.getAllGroups(); // get set of groups through the business service
-        List<Group> list_groups = new ArrayList<>(groups);
+        List<Group> list_groups = new ArrayList<>(groups); // shallow copy
 
         Group group = list_groups.get(0);
         assertNull(groupServiceImpl.createGroup(group)); // check if null because trying to create group with an id
@@ -164,7 +164,7 @@ class GroupServiceImplTest {
 
 
     private Set<Group> getGroups() {
-        Set<Group> groups = new HashSet<Group>();
+        Set<Group> groups = new HashSet<>();
         long numberOfNewGrp = Math.round((Math.random() * 10)) + 5;
         for (int i = 0; i < numberOfNewGrp; i++) {
             groups.add(getRandomGroup());


### PR DESCRIPTION
* [Previous merge](https://github.com/fabriceHategekimana/projet_informatique-moviet/pull/25#issue-650655904)

# Major features that seems to work but NOT tested:
- Delete only one user one by one from a group (add a new request DELETE at `/groups/{group_id}/users`).
- Create a group directly with one or more users ! (Also handling multiple users with same user_id)

`admin_id` can **only** be modified by updating the entire group through the POST method or at the creation of the group.
No users are deleted from `t_users`. Only removed from groups.

# TODO:
- Update/PUT cannot handle multiple users with same user_id
- Link with future authentication to assign the admin_id to the user that created the group
- Add (short-term) preferences
- Add booleans for front-end and poll-service to use to switch windows when votes are done etc.
- Update comments

`admin_id` can **only** be modified by updating the entire group through the PUT method or at the creation of the group. 
## Optional/Removed
- Add new method to modify the `admin_id` only
- Add new method to modify the `name` of the group only
- ~~Add new method to get only a list of user ids~~ (not useful for front-end for Raphaël because getting a group already has that information)
- Maybe rename users to **members**