### PR TITLE
Group service - Added group_status and skip all users_status/group_status

### DIFF
--- a/docker-compose/data/groups/groups.sql
+++ b/docker-compose/data/groups/groups.sql
@@ -1,10 +1,14 @@
 DROP TABLE if exists T_groups CASCADE;
+DROP TYPE if exists status_type;
+-- choosing : for short term preferences, ready: before vote
+CREATE TYPE status_type AS ENUM ('CHOOSING','READY', 'VOTING', 'DONE');
 -- need to be in one-line otherwise tons of errors..
 -- best website to test SQL online ! https://sqliteonline.com
 CREATE TABLE T_groups (
     group_id serial primary key,
     name varchar(255) not null,
-    admin_id int not null
+    admin_id int not null,
+    group_status status_type DEFAULT 'CHOOSING'
 );
 -- Grant SQL commands: https://www.ibm.com/docs/en/qmf/11.2?topic=privileges-sql-grant-statement
 -- GRANT SELECT, UPDATE, INSERT, DELETE ON ALL TABLES IN SCHEMA public to group-service;
@@ -27,9 +31,9 @@ INSERT INTO T_users (user_id) VALUES (3);
 INSERT INTO T_users (user_id) VALUES (4);
 
 DROP TABLE if exists T_groups_users CASCADE;
-DROP TYPE if exists status_type;
+-- DROP TYPE if exists status_type;
 -- choosing : for short term preferences, ready: before vote
-CREATE TYPE status_type AS ENUM ('CHOOSING','READY', 'VOTING', 'DONE');  -- change of status changes in the same order
+-- CREATE TYPE status_type AS ENUM ('CHOOSING','READY', 'VOTING', 'DONE');  -- change of status changes in the same order
 -- cannot have users ready while others are voting..
 -- status status_type not null,
 CREATE TABLE T_groups_users (

--- a/group-service/src/main/java/api/GroupRestService.java
+++ b/group-service/src/main/java/api/GroupRestService.java
@@ -289,14 +289,14 @@ public class GroupRestService {
     @Path("/{group_id}/users_status")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Changes all the status in the group to Voting")
-    public Response changeToVotingAllUserStatus(@PathParam("group_id") String str_id){
+    public Response skipAllUserStatus(@PathParam("group_id") String str_id){
         /*
-        Changes all the status in the group to Voting
+        Changes all the status in the group to Voting or to Done
          */
         try {
             log.info("Trying to change all the status in the group to Voting using: id=" + str_id);
             int group_id = Integer.parseInt(str_id);
-            Map<Integer, Status> outMap = groupService.changeToVotingAllUserStatus(group_id);
+            Map<Integer, Status> outMap = groupService.skipAllUserStatus(group_id);
             if (outMap == null){
                 // group not found
                 return Response.status(Response.Status.NOT_FOUND).build(); // 404

--- a/group-service/src/main/java/api/GroupRestService.java
+++ b/group-service/src/main/java/api/GroupRestService.java
@@ -235,6 +235,28 @@ public class GroupRestService {
     }
 
     @GET
+    @Path("/{group_id}/group_status")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "GET a particular group status")
+    public Response getGroupStatus(@PathParam("group_id") String str_group_id) {
+        try {
+            log.info("Trying get a group status of a Group having group_id=" + str_group_id);
+            int group_id = Integer.parseInt(str_group_id);
+
+            Status status=groupService.getGroupStatus(group_id);
+            if (status == null){
+                // group does not exist already
+                return Response.status(Response.Status.NOT_FOUND).build(); // 404
+            }
+            return Response.ok(status).build(); // 200
+        }
+        catch(NumberFormatException e){ // invalid id
+            return Response.status(Response.Status.BAD_REQUEST).entity("BAD_REQUEST : Invalid group id, it should be numerical: group_id = " + str_group_id).build();
+        }
+    }
+
+
+    @GET
     @Path("/{group_id}/users/{user_id}/status") // TODO: remove /status to be more general ?, like for short term preferences
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "GET a particular user status")
@@ -263,7 +285,7 @@ public class GroupRestService {
     @ApiOperation(value = "GET a particular user status")
     public Response updateUserStatus(@PathParam("group_id") String str_group_id, @PathParam("user_id") String str_user_id, String status) {
         try {
-            log.info("Trying get a user status of user with user_id=" + str_user_id + "from a Group having group_id=" + str_group_id);
+            log.info("Trying update a user status of user with user_id=" + str_user_id + "from a Group having group_id=" + str_group_id);
             int group_id = Integer.parseInt(str_group_id);
             int user_id = Integer.parseInt(str_user_id);
 
@@ -291,17 +313,17 @@ public class GroupRestService {
     @ApiOperation(value = "Changes all the status in the group to Voting")
     public Response skipAllUserStatus(@PathParam("group_id") String str_id){
         /*
-        Changes all the status in the group to Voting or to Done
+        Skip group status ! Changes all the status in the group to Voting or to Done
          */
         try {
             log.info("Trying to change all the status in the group to Voting using: id=" + str_id);
             int group_id = Integer.parseInt(str_id);
-            Map<Integer, Status> outMap = groupService.skipAllUserStatus(group_id);
-            if (outMap == null){
+            Status status = groupService.skipAllUserStatus(group_id);
+            if (status == null){
                 // group not found
                 return Response.status(Response.Status.NOT_FOUND).build(); // 404
             }
-            return Response.ok(outMap).build(); // 200
+            return Response.ok(status).build(); // 200
         }
         catch(NumberFormatException e){ // invalid id
             return Response.status(Response.Status.BAD_REQUEST).entity("BAD_REQUEST : Invalid group id, it should be numerical: id = " + str_id).build();

--- a/group-service/src/main/java/domain/model/Group.java
+++ b/group-service/src/main/java/domain/model/Group.java
@@ -8,27 +8,23 @@ import lombok.ToString;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
 
+import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 // https://projectlombok.org/features/all
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
-import javax.persistence.Column;
-
-import javax.persistence.ManyToMany;
-import javax.persistence.CascadeType;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
 // https://youtu.be/FeZ5BC0PirQ
 
 @ToString
 @Getter
 @NoArgsConstructor // need this otherwise can have some problems with PUT (create) requests
 @Entity @Table( name="T_groups")// JPA, mapping class - table
+@TypeDef( // https://vladmihalcea.com/the-best-way-to-map-an-enum-type-with-jpa-and-hibernate/
+        name = "status_db_enum",
+        typeClass = StatusDatabaseEnumType.class
+)
 public class Group {
     @Id @GeneratedValue( strategy=GenerationType.IDENTITY ) // Generated Value, automatically generated following how the db was configured
     @Column(name="group_id")
@@ -46,6 +42,10 @@ public class Group {
     @Setter
     private Set<User> users = new HashSet<>();  // https://www.appsdeveloperblog.com/infinite-recursion-in-objects-with-bidirectional-relationships/
     // https://thorben-janssen.com/6-hibernate-mappings-you-should-avoid-for-high-performance-applications/
+
+    @Setter @Enumerated(EnumType.STRING) @Type( type = "status_db_enum" )
+    private Status group_status = Status.CHOOSING;
+
     public Group(String name){
         this.name = name;
     }

--- a/group-service/src/main/java/domain/service/GroupService.java
+++ b/group-service/src/main/java/domain/service/GroupService.java
@@ -16,6 +16,7 @@ public interface GroupService{
     Map<Integer,Status> getAllUserStatus(int group_id); // called by GET request
     Status getUserStatus(int group_id, int user_id); // called by GET request
     Status updateUserStatus(int group_id, int user_id, String status); // called by PUT request
-    Map<Integer,Status> skipAllUserStatus(int group_id); // called by PUT request
+    Status skipAllUserStatus(int group_id); // called by PUT request
+    Status getGroupStatus(int group_id); // called by GET request
     Group deleteGroup(int id); // called by DELETE request
 }

--- a/group-service/src/main/java/domain/service/GroupService.java
+++ b/group-service/src/main/java/domain/service/GroupService.java
@@ -16,6 +16,6 @@ public interface GroupService{
     Map<Integer,Status> getAllUserStatus(int group_id); // called by GET request
     Status getUserStatus(int group_id, int user_id); // called by GET request
     Status updateUserStatus(int group_id, int user_id, String status); // called by PUT request
-    Map<Integer,Status> changeToVotingAllUserStatus(int group_id); // called by PUT request
+    Map<Integer,Status> skipAllUserStatus(int group_id); // called by PUT request
     Group deleteGroup(int id); // called by DELETE request
 }

--- a/group-service/src/main/resources/META-INF/groups_test.sql
+++ b/group-service/src/main/resources/META-INF/groups_test.sql
@@ -1,6 +1,9 @@
 DROP TABLE if exists T_groups CASCADE;
+DROP TYPE if exists status_type;
+-- choosing : for short term preferences, ready: before vote
+CREATE TYPE status_type AS ENUM ('CHOOSING','READY', 'VOTING', 'DONE');
 -- need to be in one-line otherwise tons of errors..
-CREATE TABLE T_groups (group_id serial primary key, name varchar(255) not null, admin_id int not null);
+CREATE TABLE T_groups (group_id serial primary key, name varchar(255) not null, admin_id int not null, group_status status_type DEFAULT 'CHOOSING');
 -- Grant SQL commands: https://www.ibm.com/docs/en/qmf/11.2?topic=privileges-sql-grant-statement
 -- GRANT SELECT, UPDATE, INSERT, DELETE ON ALL TABLES IN SCHEMA public to group-service;
 -- Truncate is here to purge the table without deleting the table: https://sql.sh/cours/truncate-table
@@ -20,9 +23,9 @@ INSERT INTO T_users (user_id) VALUES (3);
 INSERT INTO T_users (user_id) VALUES (4);
 
 DROP TABLE if exists T_groups_users CASCADE;
-DROP TYPE if exists status_type;
+-- DROP TYPE if exists status_type;
 -- choosing : for short term preferences, ready: before vote
-CREATE TYPE status_type AS ENUM ('CHOOSING','READY', 'VOTING', 'DONE');  -- change of status changes in the same order
+-- CREATE TYPE status_type AS ENUM ('CHOOSING','READY', 'VOTING', 'DONE');  -- change of status changes in the same order
 -- cannot have users ready while others are voting..
 -- status status_type not null,
 CREATE TABLE T_groups_users (id serial primary key, group_id int REFERENCES T_groups(group_id), user_id int REFERENCES T_users(user_id), user_status status_type DEFAULT 'CHOOSING');

--- a/group-service/src/test/java/domain/model/GroupTest.java
+++ b/group-service/src/test/java/domain/model/GroupTest.java
@@ -35,6 +35,11 @@ class GroupTest {
     }
 
     @Test
+    void testGetGroup_status(){
+        assertEquals(0, new Group().getUsers().size() );
+    }
+
+    @Test
     void testSetName(){
         Group tmpgroup = new Group("hello world");
         tmpgroup.setName("hello universe");
@@ -98,6 +103,11 @@ class GroupTest {
     }
 
     @Test
+    void testSetGroup_status(){
+        assertEquals(Status.CHOOSING, new Group().getGroup_status() );
+    }
+
+    @Test
     void testGetIdNoArgsConstructor(){
         assertEquals(0, new Group().getId() );
     }
@@ -119,6 +129,6 @@ class GroupTest {
 
     @Test
     void testToString(){
-        assertEquals("Group(id=0, name=hello world, admin_id=0, users=[])", group.toString() );
+        assertEquals("Group(id=0, name=hello world, admin_id=0, users=[], group_status=CHOOSING)", group.toString() );
     }
 }

--- a/group-service/src/test/resources/META-INF/groups_test.sql
+++ b/group-service/src/test/resources/META-INF/groups_test.sql
@@ -1,6 +1,9 @@
 DROP TABLE if exists T_groups CASCADE;
+DROP TYPE if exists status_type;
+-- choosing : for short term preferences, ready: before vote
+CREATE TYPE status_type AS ENUM ('CHOOSING','READY', 'VOTING', 'DONE');
 -- need to be in one-line otherwise tons of errors..
-CREATE TABLE T_groups (group_id serial primary key, name varchar(255) not null, admin_id int not null);
+CREATE TABLE T_groups (group_id serial primary key, name varchar(255) not null, admin_id int not null, group_status status_type DEFAULT 'CHOOSING');
 -- Grant SQL commands: https://www.ibm.com/docs/en/qmf/11.2?topic=privileges-sql-grant-statement
 -- GRANT SELECT, UPDATE, INSERT, DELETE ON ALL TABLES IN SCHEMA public to group-service;
 -- Truncate is here to purge the table without deleting the table: https://sql.sh/cours/truncate-table
@@ -20,9 +23,9 @@ INSERT INTO T_users (user_id) VALUES (3);
 INSERT INTO T_users (user_id) VALUES (4);
 
 DROP TABLE if exists T_groups_users CASCADE;
-DROP TYPE if exists status_type;
+-- DROP TYPE if exists status_type;
 -- choosing : for short term preferences, ready: before vote
-CREATE TYPE status_type AS ENUM ('CHOOSING','READY', 'VOTING', 'DONE');  -- change of status changes in the same order
+-- CREATE TYPE status_type AS ENUM ('CHOOSING','READY', 'VOTING', 'DONE');  -- change of status changes in the same order
 -- cannot have users ready while others are voting..
 -- status status_type not null,
 CREATE TABLE T_groups_users (id serial primary key, group_id int REFERENCES T_groups(group_id), user_id int REFERENCES T_users(user_id), user_status status_type DEFAULT 'CHOOSING');


### PR DESCRIPTION
* [Previous merge](https://github.com/fabriceHategekimana/projet_informatique-moviet/pull/28#issue-657438428)

# Major features that seems to work but NOT tested:
- Added `group_status` in Group table for each pair using `@Enumerated` annotation + default status is `CHOOSING`. Status possible : `CHOOSING`, `READY`, `VOTING`, `DONE` (actually, we will never use `READY`).
- GET a `group_status` at `groups/{group_id}/group_status`
- This method below no longer exist or was modified and is replaced by `Status skipAllUserStatus(int group_id);` that will skip all `users_status` from `VOTING`/`DONE` to `DONE` and change the `group_status` to `DONE` or otherwise change all `users_status` and `group_status` to `VOTING`
> PUT, change the status of all users from a group to `VOTING` at `groups/{group_id}/users_status` (**no constraint like for the next method**)

- This method below now also handles the `group_status` being updated to `VOTING` or `DONE` when all `users_status` are `READY` or `DONE`.
> PUT, change one user status from a group to `<status>` at `groups/{group_id}/users/{user_id}/status` where `<status>` is in the body of the request and can be any of the status possible ...
- An important detail is that the `group_status` becomes `CHOOSING` when any `users_status` changes to `CHOOSING`.
